### PR TITLE
task/Use-Docker-volumes-for-cached-files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN set -eux; apk add --no-cache\
 ARG SBT_VERSION
 RUN wget -qO- https://github.com/sbt/sbt/releases/download/v${SBT_VERSION}/sbt-${SBT_VERSION}.tgz |\
  tar zxf - -C /opt &&\
- ln -s /opt/sbt/bin/sbt /usr/bin
+ ln -s /opt/sbt/bin/sbt /usr/local/bin
 
 # Add our user and group first to make sure their IDs get assigned consistently,
 # regardless of whatever dependencies get added.

--- a/Makefile
+++ b/Makefile
@@ -25,22 +25,17 @@ MAKESTER__BUILD_COMMAND = $(DOCKER) build\
 MAKESTER__RUN_COMMAND := $(DOCKER) run --rm -ti\
  $(MAKESTER__SERVICE_NAME):$(HASH)
 
-sbt: HOST_COURSIER_CACHE := ~/.cache/coursier
-sbt: HOST_SBT_WORKING_DIR := ~/.sbt
-sbt: HOST_IVY2_WORKING_DIR := ~/.ivy2
+sbt: HOST_IVY2_WORKING_DIR := $(HOME)/.ivy2
 sbt:
-	@$(shell mkdir -pv\
- $(HOST_COURSIER_CACHE)\
- $(HOST_SBT_WORKING_DIR)\
- $(HOST_IVY2_WORKING_DIR))
+	@mkdir -pv $(HOST_IVY2_WORKING_DIR)
 	@$(DOCKER) run --rm -ti\
- -v ~/.cache/coursier:/home/sbt/.cache/coursier\
- -v ~/.ivy2:/home/sbt/.ivy2\
- -v $(PWD):/app\
- -v ~/.sbt:/home/sbt/.sbt\
+ -v $(HOST_IVY2_WORKING_DIR):/home/sbt/.ivy2\
+ -v sbtvol:/home/sbt/.sbt\
+ -v cachevol:/home/sbt/.cache\
+ --mount type=bind,source=$(PWD),target=/app\
  -e COURSIER_CACHE=/home/sbt/.cache/coursier\
  $(MAKESTER__SERVICE_NAME):$(HASH)\
- $(CMD)
+ $(CMD) || true
 
 sbt-help: CMD = help
 sbt-version: CMD = about


### PR DESCRIPTION
- emphasising that current behaviour is only supported if your Docker daemon does not run natively on your host OS but transparently in a virtual machine (for example, macOS or Windows)
- rather than writing to underlying host's filesystem, let's use Docker volumes where possible